### PR TITLE
Including linalg_obj.h in matrix.c.

### DIFF
--- a/matrix.c
+++ b/matrix.c
@@ -6,6 +6,7 @@
 #include "vector.h"
 #include "errors.h"
 #include "util.h"
+#include "linalg_obj.h"
 
 
 #define MATRIX_ROW(M, i) ((i) / (M->n_row))


### PR DESCRIPTION
Some of the macros defined in linalg_obj.h are
used in matrix.c. It was compiling okay but
eclipse IDE was unable to resolve them without
the include.
